### PR TITLE
Properly permit array params

### DIFF
--- a/lib/filterrific/param_set.rb
+++ b/lib/filterrific/param_set.rb
@@ -31,7 +31,13 @@ module Filterrific
       if defined?(ActionController::Parameters) && filterrific_params.is_a?(ActionController::Parameters)
         permissible_filter_params = []
         model_class.filterrific_available_filters.each do |p|
-          permissible_filter_params << (filterrific_params[p].is_a?(ActionController::Parameters) ? { p => filterrific_params[p].keys } : p)
+          if filterrific_params[p].is_a?(Hash)
+            permissible_filter_params << { p => filterrific_params[p].keys }
+          elsif filterrific_params[p].is_a?(Array)
+            permissible_filter_params << { p => [] }
+          else
+            permissible_filter_params << p
+          end
         end
         filterrific_params = filterrific_params.permit(permissible_filter_params).to_h.stringify_keys
       else

--- a/lib/filterrific/param_set.rb
+++ b/lib/filterrific/param_set.rb
@@ -31,7 +31,7 @@ module Filterrific
       if defined?(ActionController::Parameters) && filterrific_params.is_a?(ActionController::Parameters)
         permissible_filter_params = []
         model_class.filterrific_available_filters.each do |p|
-          if filterrific_params[p].is_a?(Hash)
+          if filterrific_params[p].is_a?(ActionController::Parameters)
             permissible_filter_params << { p => filterrific_params[p].keys }
           elsif filterrific_params[p].is_a?(Array)
             permissible_filter_params << { p => [] }


### PR DESCRIPTION
Permit array parameters in filterrific_params. With this change, you can filter
by multiple values from a select.
All credit goes to [@patrocc6](github.com/patrocc6) for this, see
https://github.com/jhund/filterrific/issues/113#issuecomment-263760456